### PR TITLE
fix🛠️: fixed the text Alignment (#2)

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -309,7 +309,7 @@ img {
 
 .skills__names {
   display: flex;
-  align-items: center;
+  align-items:left;
 }
 
 .skills__bar {


### PR DESCRIPTION
This pull closes #2 issue by aligning the skills title texts to the `left`. To purpose a better organization and to save more space for the skills logo's.